### PR TITLE
Deprecate OmniDiskSweeper recipes

### DIFF
--- a/OmniGroup/OmniDiskSweeper.munki.recipe
+++ b/OmniGroup/OmniDiskSweeper.munki.recipe
@@ -31,9 +31,18 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the OmniDiskSweeper.munki recipe in the autopkg/recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>

--- a/OmniGroup/OmniDiskSweeper.pkg.recipe
+++ b/OmniGroup/OmniDiskSweeper.pkg.recipe
@@ -14,9 +14,18 @@
         <string>https://update.omnigroup.com/appcast/com.omnigroup.OmniDiskSweeper</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the OmniDiskSweeper.pkg recipe in the autopkg/recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
This PR deprecates the OmniDiskSweeper recipes in preparation for repository archive (https://github.com/autopkg/luisgiraldo-recipes/issues/4).